### PR TITLE
fix: jump to pipeline page if cluster is created

### DIFF
--- a/src/pages/clusters/NewOrEdit/v1/index.tsx
+++ b/src/pages/clusters/NewOrEdit/v1/index.tsx
@@ -267,7 +267,11 @@ export default (props: any) => {
 
   const onBuildAndDeployButtonOK = () => {
     setShowBuildDeployModal(false);
-    setEnableRebuilddeployModal(true);
+    if (creating) {
+      window.location.href = `/clusters${cluster!.fullPath}/-/pipelines/new?type=${PublishType.BUILD_DEPLOY}`;
+    } else {
+      setEnableRebuilddeployModal(true);
+    }
   };
 
   const onDeployButtonOK = () => {

--- a/src/pages/clusters/NewOrEdit/v2/index.tsx
+++ b/src/pages/clusters/NewOrEdit/v2/index.tsx
@@ -292,7 +292,11 @@ export default (props: any) => {
 
   const onBuildAndDeployButtonOK = () => {
     setShowBuildDeployModal(false);
-    setEnableRebuilddeployModal(true);
+    if (creating) {
+      window.location.href = `/clusters${cluster!.fullPath}/-/pipelines/new?type=${PublishType.BUILD_DEPLOY}`;
+    } else {
+      setEnableRebuilddeployModal(true);
+    }
   };
 
   const onDeployButtonOK = () => {


### PR DESCRIPTION
* On the cluster creation page, click `Builddeploy` in the prompt box to jump pipeline page directly